### PR TITLE
Skip instance if it doesn't have a 'users' field

### DIFF
--- a/usercount.py
+++ b/usercount.py
@@ -87,6 +87,7 @@ instances = json.loads(page.content)
 user_count = 0
 instance_count = 0
 for instance in instances:
+    if not "users" in instance: continue
     user_count += instance["users"]
     if instance["up"] == True:
         instance_count += 1


### PR DESCRIPTION
This fixes an exception encountered while collating the instance data if instances.mastodon.xyz returns a row without a "users" field